### PR TITLE
Fix PS1 usage and make it more readable

### DIFF
--- a/ps1.bash
+++ b/ps1.bash
@@ -1,33 +1,33 @@
 function begin_teal()
 {
-  echo '\033[38;5;38m'
+  echo -n '\[\033[38;5;38m\]'
 }
 
 function begin_yellow()
 {
-  echo '\033[38;5;226m'
+  echo -n '\[\033[38;5;226m\]'
 }
 
 function begin_red()
 {
-  echo '\033[38;5;196m'
+  echo -n '\[\033[38;5;196m\]'
 }
 
 function clear_color()
 {
-  echo '\033[00m'
+  echo -n '\[\033[00m\]'
 }
 
 function possible_chroot_prefix()
 {
-  echo "${debian_chroot:+($debian_chroot) }"
+  echo -n "${debian_chroot:+($debian_chroot) }"
 }
 
 function git_parent()
 {
   if git rev-parse --git-dir 1> /dev/null 2>&1
   then
-    echo "$(basename "$(readlink -f "$(git rev-parse --git-dir 2> /dev/null)/../..")") "
+    echo -n "$(basename "$(readlink -f "$(git rev-parse --git-dir 2> /dev/null)/../..")") "
   fi
 }
 
@@ -35,9 +35,9 @@ function curdir_or_tilde()
 {
   if [ "$HOME" == "$PWD" ]
   then
-    echo '~'
+    echo -n '~'
   else
-    basename "$PWD"
+    echo -n "$(basename "$PWD")"
   fi
 }
 
@@ -45,13 +45,24 @@ function git_abbrev_ref()
 {
   if git rev-parse --git-dir 1> /dev/null 2>&1
   then
-    echo "$(git rev-parse --abbrev-ref HEAD) "
+    echo -n "$(git rev-parse --abbrev-ref HEAD) "
   fi
 }
 
 function join_ps1()
 {
-  echo -en "$(possible_chroot_prefix)[$(begin_yellow)$(git_parent)$(clear_color)$(begin_red)$(git_abbrev_ref)$(clear_color)$(begin_teal)$(curdir_or_tilde)$(clear_color)]\$ "
+  possible_chroot_prefix
+  echo -n '['
+  begin_yellow
+  git_parent
+  clear_color
+  begin_red
+  git_abbrev_ref
+  clear_color
+  begin_teal
+  curdir_or_tilde
+  clear_color
+  echo -n ']$ '
 }
 
-PS1="\`join_ps1\`"
+PROMPT_COMMAND='PS1="$(join_ps1)"'


### PR DESCRIPTION
bash doesn't know when chars aren't displayed via PS1. Thus within PS1 \[ and \] should be used around characters that aren't displayed so they aren't counted. These are special cases for PS1 specifically so they need to be inside PS1 when it's value is used. NOT as apart of expansion/execution within the PS1 otherwise they just come through as regular characters and don't do the job they're meant to do.

To deal with this I've given PROMPT_COMMAND a value to set the PS1 ahead of time. This makes it so that PS1 is set to the expanded output BEFORE it's read for use. Note, PROMPT_COMMAND can be an array of commands if more comands are desired later.